### PR TITLE
Add tip to not manually register command handlers in the DI container

### DIFF
--- a/src/routes/docs/[...13]command-bus.md
+++ b/src/routes/docs/[...13]command-bus.md
@@ -186,6 +186,10 @@ bld.Services.AddCommandMiddleware(c => c.Register<MyCommand, string, ClosedGener
 
 ## Dependency Injection
 
+:::admonition type=warning
+Do not manually register command handlers with the DI container. The library handles registration automatically, and manual registration can interfere with runtime resolution and break scoped service functionality.
+:::
+
 Dependencies in command handlers can be resolved as described [here](dependency-injection#command-handler-dependencies).
 
 ## Command Bus Without FastEndpoints

--- a/src/routes/docs/[...13]command-bus.md
+++ b/src/routes/docs/[...13]command-bus.md
@@ -186,8 +186,8 @@ bld.Services.AddCommandMiddleware(c => c.Register<MyCommand, string, ClosedGener
 
 ## Dependency Injection
 
-:::admonition type=warning
-Do not manually register command handlers with the DI container. The library handles registration automatically, and manual registration can interfere with runtime resolution and break scoped service functionality.
+:::admonition type="tip"
+You do not need to register command handlers with the IOC container. The library will automatically scan for all command handlers in the loaded assemblies and register them as transient services.
 :::
 
 Dependencies in command handlers can be resolved as described [here](dependency-injection#command-handler-dependencies).

--- a/src/routes/docs/[...5]dependency-injection.md
+++ b/src/routes/docs/[...5]dependency-injection.md
@@ -279,6 +279,10 @@ public class MyEventHandler : IEventHandler<MyEvent>
 
 ## Command Handler Dependencies
 
+:::admonition type=warning
+Do not manually register command handlers with the DI container. The library handles registration automatically, and manual registration can interfere with runtime resolution and break scoped service functionality.
+:::
+
 Unlike event handlers, command handlers are not singletons and the constructor is executed per each command execution. Scoped dependencies can therefore simply be
 injected using the constructor and used inside the execute method like so:
 

--- a/src/routes/docs/[...5]dependency-injection.md
+++ b/src/routes/docs/[...5]dependency-injection.md
@@ -279,10 +279,6 @@ public class MyEventHandler : IEventHandler<MyEvent>
 
 ## Command Handler Dependencies
 
-:::admonition type=warning
-Do not manually register command handlers with the DI container. The library handles registration automatically, and manual registration can interfere with runtime resolution and break scoped service functionality.
-:::
-
 Unlike event handlers, command handlers are not singletons and the constructor is executed per each command execution. Scoped dependencies can therefore simply be
 injected using the constructor and used inside the execute method like so:
 


### PR DESCRIPTION
As discussed in https://github.com/FastEndpoints/FastEndpoints/issues/1056 added a little tip so that people don't waste time adding their command handlers manually 