### PR TITLE
docs: fix typos and align Send.StatusCode example method name

### DIFF
--- a/src/content/docs/04-validation.md
+++ b/src/content/docs/04-validation.md
@@ -51,7 +51,7 @@ If a request is received that doesn't meet the above model validation criteria, 
 ```json |title=json
 {
   "StatusCode": 400,
-  "Message": "One or more errors occured!",
+  "Message": "One or more errors occurred!",
   "Errors": {
     "FullName": [
       "your name is required!",

--- a/src/content/docs/13-command-bus.md
+++ b/src/content/docs/13-command-bus.md
@@ -119,7 +119,7 @@ In this particular case, the client will receive the following error response:
 ```json |title=json
 {
   "statusCode": 400,
-  "message": "One or more errors occured!",
+  "message": "One or more errors occurred!",
   "errors": {
     "generalErrors": [
       "an error added by the endpoint!",

--- a/src/content/docs/19-integration-unit-testing.md
+++ b/src/content/docs/19-integration-unit-testing.md
@@ -258,7 +258,7 @@ This approach allows your test suite to have just a couple of derived **AppFixtu
 
 ### Test-Collections & Collection Fixtures
 
-A test-collection is an arbitrary grouping of multiple test-classes which results in all test-methods of the collection running serially (never in parallel) in order to avoid contention between test-methods from multiple test-classes. A test-collection can be thought of as a mega test-class but physically seperated into multiple class files.
+A test-collection is an arbitrary grouping of multiple test-classes which results in all test-methods of the collection running serially (never in parallel) in order to avoid contention between test-methods from multiple test-classes. A test-collection can be thought of as a mega test-class but physically separated into multiple class files.
 
 An **AppFixture** can be made into a [collection-fixture](https://xunit.net/docs/shared-context#collection-fixture) for the purpose of being shared just among the test-classes of a given collection. It will be instantiated before any of the tests from the collection is run and torn down once all tests from the collection is complete. Inherit from **AppFixture<TProgram>** as usual:
 

--- a/src/content/docs/21-misc-conveniences.md
+++ b/src/content/docs/21-misc-conveniences.md
@@ -109,7 +109,7 @@ If the provided response sending methods are not sufficient, you can easily add 
 ```cs
 public static class SendExtensions
 {
-    public static Task SendStatusCode(this IResponseSender sender, int statusCode)
+    public static Task StatusCode(this IResponseSender sender, int statusCode)
     {
         sender.HttpContext.MarkResponseStart(); //don't forget to always do this
         sender.HttpContext.Response.StatusCode = statusCode;


### PR DESCRIPTION
Three small documentation corrections:

- `21-misc-conveniences.md`: the sample defines the extension method as `SendStatusCode`, but the usage right below calls it as `await Send.StatusCode(219)`. As written the call would not resolve, so the method name should be `StatusCode` (an extension on `IResponseSender`, invoked via `Send.StatusCode(...)`).
- `04-validation.md` and `13-command-bus.md`: the sample error responses read `"One or more errors occured!"`; the actual framework message is `"One or more errors occurred!"`. Fixed the spelling so the docs match real output.
- `19-integration-unit-testing.md`: `seperated` corrected to `separated`.

Documentation only.
