### PR TITLE
Document optional [HasPermission] binding behavior

### DIFF
--- a/src/content/docs/04-model-binding.md
+++ b/src/content/docs/04-model-binding.md
@@ -751,6 +751,8 @@ The property value will be set to **true** if the current principal has the **Ar
 [HasPermission("Article_Update", IsRequired = false)]
 ```
 
+When the validation error is disabled, the property is set to **false** if the principal does not have the permission. Permission properties are only ever bound from the user's claims, so any value the client sends for them (e.g. in the JSON body) is ignored.
+
 ---
 
 ## Supported DTO Property Types


### PR DESCRIPTION
## Summary

Document that an optional `[HasPermission]` property is set to `false` when the principal lacks the permission, and that client-supplied values for permission properties (e.g. in the JSON body) are ignored.

Companion documentation update for FastEndpoints/FastEndpoints#1177.

## Validation

- [x] Changed file passes Prettier
- [x] Production documentation build passes

## Related pull request

- FastEndpoints/FastEndpoints#1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
